### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,6 @@ on:
       slack-channel:
         required: false
         type: string
-        default: 'metamask-dev'
       slack-icon-url:
         required: false
         type: string
@@ -58,12 +57,12 @@ jobs:
             {
               "text": "${{ steps.final-text.outputs.FINAL_TEXT }}",
               "icon_url": "${{ inputs.slack-icon-url }}",
-              "username": "${{ inputs.slack-username }}",
-              "channel": "#${{ inputs.slack-channel }}"
+              "username": "${{ inputs.slack-username }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        continue-on-error: true
 
   publish-release:
     name: Publish release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,9 +3,6 @@ name: Publish Release
 on:
   workflow_call:
     inputs:
-      slack-channel:
-        required: false
-        type: string
       slack-icon-url:
         required: false
         type: string


### PR DESCRIPTION
The Slack publish step was failing with an HTTP 403 error. The only difference compared to `action-npm-publish` seems to be that we're providing a channel, so I removed that. I also added `continue-on-error`, so we can publish if the Slack step fails.