### PR TITLE
Fix race condition in tests

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -10,6 +10,9 @@ jobs:
     strategy:
       matrix:
         node-version: [22.x]
+    needs:
+      - test-high-risk-without-prepare
+      - test-low-risk-without-prepare
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The "low-risk without prepare" test was failing because the cache did exist. This seems to be a race condition, because the `prepare` job finished before the action was run. I've added the tests without the prepare action as requirement for prepare, to avoid this.