### PR TITLE
Add skip-allow-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ The version of Node.js to use.
 
 Defaults to the version specified in the `.nvmrc` file.
 
+#### `skip-allow-scripts`
+
+If set to `true`, the action will skip the `yarn allow-scripts` step. This can save time if your job does not require this step.
+
+Defaults to `false`.
+
 ## Contributing
 
 ### Setup

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Node.js version to use. If not provided, will use the version specified in the `.nvmrc` file.'
     required: false
     default: ''
+  skip-allow-scripts:
+    description: 'Skip the `yarn allow-scripts` step. If your job does not need this step, skipping it will save 10-15 seconds.'
+    required: false
+    default: 'false'
 
 # The outputs are for the unit tests in `build-lint-test.yml`, and
 # probably not useful for other workflows.
@@ -99,7 +103,7 @@ runs:
     # typically run as part of the Yarn install, so we only need to run it if
     # we're restoring the cache.
     - name: Run `allow-scripts`
-      if: ${{ steps.download-node-modules.outputs.cache-hit == 'true'}}
+      if: ${{ inputs.skip-allow-scripts != 'true' && steps.download-node-modules.outputs.cache-hit == 'true'}}
       run: yarn allow-scripts || true
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: ''
   skip-allow-scripts:
-    description: 'Skip the `yarn allow-scripts` step. If your job does not need this step, skipping it will save 10-15 seconds.'
+    description: 'Skip the `yarn allow-scripts` step. If your job does not need this step, skipping it may save some time.'
     required: false
     default: 'false'
 


### PR DESCRIPTION
Allow us to skip the `yarn allow-scripts` step.  If the job does not need this step, skipping it will save some time (10-15 seconds in the `metamask-extension` repo).