### PR TITLE
fix: if we want to allow pre-existing git checkout state, we must read its commit hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,14 +58,14 @@ runs:
       uses: actions/checkout@v4
       if: ${{ hashFiles('.git') == '' }}
       with:
-      fetch-depth: ${{ inputs.fetch-depth }}
-      ref: ${{ inputs.ref }}
+        fetch-depth: ${{ inputs.fetch-depth }}
+        ref: ${{ inputs.ref }}
 
     # Get the commit hash of the checked out commit regardless of whether it
     # was checked out in the previous step or existed before.
     - name: Get commit hash
       id: get-commit-hash
-      run: echo "actual_commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      run: echo "actual-commit-hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - run: corepack enable
@@ -78,8 +78,8 @@ runs:
       id: download-node-modules
       uses: actions/cache/restore@v4
       with:
-      path: ./node_modules
-      key: node-modules-${{ steps.get-commit-hash.outputs.actual_commit_hash }}
+        path: ./node_modules
+        key: node-modules-${{ steps.get-commit-hash.outputs.actual-commit-hash }}
 
     - name: Set up Node.js
       uses: actions/setup-node@v4
@@ -121,4 +121,4 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ./node_modules
-        key: node-modules-${{ steps.get-commit-hash.outputs.actual_commit_hash }}
+        key: node-modules-${{ steps.get-commit-hash.outputs.actual-commit-hash }}

--- a/action.yml
+++ b/action.yml
@@ -58,8 +58,15 @@ runs:
       uses: actions/checkout@v4
       if: ${{ hashFiles('.git') == '' }}
       with:
-        fetch-depth: ${{ inputs.fetch-depth }}
-        ref: ${{ inputs.ref }}
+      fetch-depth: ${{ inputs.fetch-depth }}
+      ref: ${{ inputs.ref }}
+
+    # Get the commit hash of the checked out commit regardless of whether it
+    # was checked out in the previous step or existed before.
+    - name: Get commit hash
+      id: get-commit-hash
+      run: echo "actual_commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      shell: bash
 
     - run: corepack enable
       shell: bash
@@ -71,8 +78,8 @@ runs:
       id: download-node-modules
       uses: actions/cache/restore@v4
       with:
-        path: ./node_modules
-        key: node-modules-${{ github.sha }}
+      path: ./node_modules
+      key: node-modules-${{ steps.get-commit-hash.outputs.actual_commit_hash }}
 
     - name: Set up Node.js
       uses: actions/setup-node@v4
@@ -114,4 +121,4 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ./node_modules
-        key: node-modules-${{ github.sha }}
+        key: node-modules-${{ steps.get-commit-hash.outputs.actual_commit_hash }}


### PR DESCRIPTION
The action allows updates to the local git clone prior to it running, but it ignores them.

We're using `gh pr checkout "${PR_NUMBER}"` in actions triggered from default branch etc.

![lm-policy-updater-issue](https://github.com/user-attachments/assets/d64a0140-c634-4224-9cc9-2e3b17022fc8)
