### PR TITLE
Use `MetaMask/action-retry-command` for possible flaky steps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,6 @@ runs:
     # we're restoring the cache.
     - name: Run `allow-scripts`
       if: ${{ inputs.skip-allow-scripts != 'true' && steps.download-node-modules.outputs.cache-hit == 'true'}}
-      run: yarn allow-scripts || true
       uses: MetaMask/action-retry-command@v1
       with:
         command: |


### PR DESCRIPTION
Both `yarn` and `allow-scripts` can be flaky, depending on network conditions and the scripts run by `allow-scripts` (e.g., `sharp` failing to download at random). At least in the Snaps repo this is causing issues occasionally. To work around it, I've implemented `MetaMask/action-retry-command`, which will run the command up to 3 times (default) with exponential backoff time between jobs (1 second, 2 seconds, 4 seconds).