### PR TITLE
Cache nested `node_modules` directories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ runs:
       id: download-node-modules
       uses: actions/cache/restore@v4
       with:
-        path: ./node_modules
+        path: '**/node_modules'
         key: node-modules-${{ steps.get-commit-hash.outputs.actual-commit-hash }}
 
     - name: Set up Node.js
@@ -127,5 +127,5 @@ runs:
       if: ${{ inputs.is-high-risk-environment == 'false' && inputs.cache-node-modules == 'true' }}
       uses: actions/cache/save@v4
       with:
-        path: ./node_modules
+        path: '**/node_modules'
         key: node-modules-${{ steps.get-commit-hash.outputs.actual-commit-hash }}


### PR DESCRIPTION
This updates the cache step to cache `**/node_modules` instead of `./node_modules`. This is important in monorepos where dependencies may not be hoisted to the top-level `node_modules` folder, causing dependencies to be lost since Yarn isn't run if the cache is found.