### PR TITLE
fix(ci): improve node_modules cache key fallback and increase yarn in…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,8 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: '**/node_modules'
-        key: node-modules-${{ steps.get-commit-hash.outputs.actual-commit-hash }}
+        key: |
+          node-modules-${{ steps.get-commit-hash.outputs.actual-commit-hash && steps.get-commit-hash.outputs.actual-commit-hash || github.sha }}
 
     - name: Set up Node.js
       uses: actions/setup-node@v4
@@ -107,6 +108,7 @@ runs:
       with:
         command: yarn --immutable
         shell: bash
+        max-retries: 5
 
     # If the node_modules cache was found, run `yarn allow-scripts`. This is
     # typically run as part of the Yarn install, so we only need to run it if
@@ -128,4 +130,5 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: '**/node_modules'
-        key: node-modules-${{ steps.get-commit-hash.outputs.actual-commit-hash }}
+        key: |
+          node-modules-${{ steps.get-commit-hash.outputs.actual-commit-hash && steps.get-commit-hash.outputs.actual-commit-hash || github.sha }}


### PR DESCRIPTION
### **Summary of Changes**

- **Cache Key Fallback:**  
  Updated the cache key for both restoring and saving `node_modules` to use a fallback mechanism:
  ```yaml
  key: |
    node-modules-${{ steps.get-commit-hash.outputs.actual-commit-hash && steps.get-commit-hash.outputs.actual-commit-hash || github.sha }}
  ```
  This ensures that if `actual-commit-hash` is not available (e.g., in some edge cases or workflow failures), the cache will fall back to using the current `github.sha`. This makes cache hits more reliable and reduces the risk of cache misses due to missing commit hash output.

- **Increase Yarn Install Retries:**  
  Increased the `max-retries` for the `yarn --immutable` install step from the default to **5**.  
  This provides additional resilience against transient network or registry issues during dependency installation, reducing the likelihood of CI failures due to temporary errors.

---

### **What Are We Trying to Improve?**

- **Cache Reliability:**  
  By making the cache key more robust, we reduce the risk of missing the cache due to missing or unavailable commit hash information. This helps ensure that jobs can restore and save the `node_modules` cache more consistently, improving CI speed and reliability.

- **Resilience to Transient Failures:**  
  Increasing the retry count for Yarn installs helps mitigate issues where network or registry errors (such as HTTP 429 or other transient failures) might otherwise cause the job to fail. This is especially important in CI environments where such errors can be intermittent.

---

### **Why Are These Changes Needed?**

- **CI Stability:**  
  We have observed intermittent CI failures, sometimes due to cache misses (caused by missing commit hash) or transient errors during dependency installation. These changes directly address those pain points.

---

### **Notes**

- This PR does **not** change the fundamental workflow logic or introduce new dependencies.
- No breaking changes are expected.
- The changes are minimal and targeted for reliability and resilience.

---

**See:**  
- [CI flakiness](https://github.com/MetaMask/metamask-extension/actions/runs/15070173571/job/42364452666?pr=32555)
- [INFRA-2575](https://consensyssoftware.atlassian.net/browse/INFRA-2575)




