### PR TITLE
feat(yarn-local-binary): Allow to use local stored yarn binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ This TypeScript module is maintained in the style of the MetaMask team.
     yarn-install-max-retries: 5
 ```
 
+#### Using Yarn Hydration
+
+```yaml
+- name: Checkout and setup with Yarn hydration
+  uses: MetaMask/action-checkout-and-setup@v1
+  with:
+    is-high-risk-environment: false
+    use-yarn-hydrate: true
+    yarn-hydrate-command: 'yarn-binary:hydrate'  # optional, this is the default
+```
+
 ### Options
 
 #### `is-high-risk-environment`
@@ -99,6 +110,18 @@ Defaults to `''` (not set).
 Sets the maximum number of retries for the `yarn --immutable` install command. This helps handle transient network errors more gracefully in CI environments.
 
 Defaults to `5`.
+
+#### `use-yarn-hydrate`
+
+If set to `true`, the action will use a yarn hydration command instead of downloading yarn from a URL. When enabled, this skips the custom yarn URL download step and runs the specified hydration command instead. This is useful when your repository has a local yarn binary that can be hydrated.
+
+Defaults to `false`.
+
+#### `yarn-hydrate-command`
+
+Specifies the npm script command to run for yarn hydration when `use-yarn-hydrate` is set to `true`. This command should be available in the package.json scripts of the repository using this action.
+
+Defaults to `yarn-binary:hydrate`.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
     description: 'Optional custom URL for a Yarn bundle to be prepared and activated by Corepack'
     required: false
     default: ''
+  use-yarn-hydrate:
+    description: 'Use yarn hydration command instead of downloading yarn. When true, skips the custom yarn URL download.'
+    required: false
+    default: 'false'
+  yarn-hydrate-command:
+    description: 'Command to run for yarn hydration. Defaults to "yarn-binary:hydrate"'
+    required: false
+    default: 'npm run yarn-binary:hydrate' # Default command in Metamask extension
 
 # The outputs are for the unit tests in `build-lint-test.yml`, and
 # probably not useful for other workflows.
@@ -79,16 +87,24 @@ runs:
     - run: corepack enable
       shell: bash
 
-    # Prepare and activate custom Yarn if URL is provided.
+    # Prepare and activate custom Yarn if URL is provided and hydration is not enabled.
     # This runs *before* setup-node might try to cache a standard Yarn.
     - name: Prepare and activate custom Yarn
-      if: ${{ env.YARN_CUSTOM_URL }}
+      if: ${{ env.YARN_CUSTOM_URL && inputs.use-yarn-hydrate != 'true' }}
       env:
         COREPACK_ENABLE_UNSAFE_CUSTOM_URLS: 1
         YARN_CUSTOM_URL: ${{ inputs.yarn-custom-url }}
       run: |
         echo "Preparing and activating custom Yarn from URL: $YARN_CUSTOM_URL"
         corepack prepare "yarn@$YARN_CUSTOM_URL" --activate
+      shell: bash
+
+    # Hydrate yarn using the specified command when hydration is enabled
+    - name: Hydrate Yarn
+      if: ${{ inputs.use-yarn-hydrate == 'true' }}
+      run: |
+        echo "Hydrating Yarn using command: ${{ inputs.yarn-hydrate-command }}"
+        npm run ${{ inputs.yarn-hydrate-command }}
       shell: bash
 
     # In a low-risk environment, try to download cache of `node_modules`, if it


### PR DESCRIPTION
If the project has a local yarn binary stored, it can be hydrated instead of downloading the binary from a source.

This would save time during the execution of the tests and will avoid false positives when there are some network problems to download the Yarn binary from the source.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
