### PR TITLE
fix: Add retry mechanism for `.nvmrc` and `yarn.lock` downloads

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -204,11 +204,6 @@ runs:
         echo "Using Node.js version: ${{ steps.setup-node.outputs.node-version }}"
       shell: bash
 
-    - name: Remove globally installed Yarn
-      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' }}
-      run: npm uninstall -g yarn
-      shell: bash
-
     - run: corepack enable
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' }}
       shell: bash
@@ -252,6 +247,10 @@ runs:
         #      restore the `node_modules` folder from cache, there's no need to
         #      download the `.yarn` folder too
         cache: 'yarn'
+
+    - name: Ensure Node is first in PATH
+      run: echo "$(dirname $(which node))" >> "$GITHUB_PATH"
+      shell: bash
 
     # If the node_modules cache was not found (or it's a high-risk environment),
     # run the yarn install

--- a/action.yml
+++ b/action.yml
@@ -204,6 +204,10 @@ runs:
         echo "Using Node.js version: ${{ steps.setup-node.outputs.node-version }}"
       shell: bash
 
+    - name: Remove globally installed Yarn
+      run: npm uninstall -g yarn
+      shell: bash
+
     - run: corepack enable
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -83,67 +83,69 @@ runs:
 
     - name: Synthesize our node version from inputs.node-version and .nvmrc
       id: compute-node-version
-      run: |
-        # If inputs.node-version is not provided then use .nvmrc
-        if [[ -z "$INPUT_NODE_VERSION" ]]; then
-          if [[ ! -s .nvmrc ]]; then
-            NVMRC_TMP_FILE="$(mktemp)"
-            if curl -sSf -o "$NVMRC_TMP_FILE" "https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/.nvmrc"; then
-              mv "$NVMRC_TMP_FILE" .nvmrc
-            else
-              rm -f "$NVMRC_TMP_FILE"
-              echo "::error::You must either have a .nvmrc at the requested ref, or provide the node-version input. Failed to download .nvmrc from https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/.nvmrc"
-              exit 1
+      uses: MetaMask/action-retry-command@v1
+      with:
+        shell: bash
+        command: |
+          # If inputs.node-version is not provided then use .nvmrc
+          if [[ -z "$INPUT_NODE_VERSION" ]]; then
+            if [[ ! -s .nvmrc ]]; then
+              NVMRC_TMP_FILE="$(mktemp)"
+              if curl -sSf -o "$NVMRC_TMP_FILE" "https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/.nvmrc"; then
+                mv "$NVMRC_TMP_FILE" .nvmrc
+              else
+                rm -f "$NVMRC_TMP_FILE"
+                echo "::error::You must either have a .nvmrc at the requested ref, or provide the node-version input. Failed to download .nvmrc from https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/.nvmrc"
+                exit 1
+              fi
             fi
+
+            NODE_VERSION=$(tr -d '\r\n' < .nvmrc)
+          else
+            NODE_VERSION="$INPUT_NODE_VERSION"
           fi
 
-          NODE_VERSION=$(tr -d '\r\n' < .nvmrc)
-        else
-          NODE_VERSION="$INPUT_NODE_VERSION"
-        fi
+          if [[ -z "$NODE_VERSION" ]]; then
+            echo "::error::You must either have a .nvmrc or provide the node-version input."
+            exit 1
+          fi
 
-        if [[ -z "$NODE_VERSION" ]]; then
-          echo "::error::You must either have a .nvmrc or provide the node-version input."
-          exit 1
-        fi
+          # If NODE_VERSION starts with "v" or starts with a number, take just the part before the second dot
+          # "v24.13.0" becomes "v24.13"
+          # "v24.13" stays as "v24.13"
+          # "v24" stays as "v24"
+          # "24.13.0" becomes "v24.13.0" and then "v24.13"
+          # "24.x" (with a literal x, not a wildcard) becomes "v24"
+          # "lts/*" becomes the latest LTS version from `nvm ls-remote --lts`, for example "v24.13.0", and then "v24.13"
 
-        # If NODE_VERSION starts with "v" or starts with a number, take just the part before the second dot
-        # "v24.13.0" becomes "v24.13"
-        # "v24.13" stays as "v24.13"
-        # "v24" stays as "v24"
-        # "24.13.0" becomes "v24.13.0" and then "v24.13"
-        # "24.x" (with a literal x, not a wildcard) becomes "v24"
-        # "lts/*" becomes the latest LTS version from `nvm ls-remote --lts`, for example "v24.13.0", and then "v24.13"
+          # If it starts with a number but not "v", add "v" to the beginning. For example, "24.13.0" becomes "v24.13.0"
+          if [[ "$NODE_VERSION" != v* && "$NODE_VERSION" =~ ^[0-9] ]]; then
+            NODE_VERSION="v$NODE_VERSION"
+          fi
 
-        # If it starts with a number but not "v", add "v" to the beginning. For example, "24.13.0" becomes "v24.13.0"
-        if [[ "$NODE_VERSION" != v* && "$NODE_VERSION" =~ ^[0-9] ]]; then
-          NODE_VERSION="v$NODE_VERSION"
-        fi
+          # Normalize major-range inputs like "24.x" to major-only "v24".
+          # We use the computed version as part of a cache key, and the patch/minor
+          # part of an "X.x" range isn't stable or meaningful for that purpose.
+          if [[ "$NODE_VERSION" =~ ^v([0-9]+)\.x$ ]]; then
+            NODE_VERSION="v${BASH_REMATCH[1]}"
+          fi
 
-        # Normalize major-range inputs like "24.x" to major-only "v24".
-        # We use the computed version as part of a cache key, and the patch/minor
-        # part of an "X.x" range isn't stable or meaningful for that purpose.
-        if [[ "$NODE_VERSION" =~ ^v([0-9]+)\.x$ ]]; then
-          NODE_VERSION="v${BASH_REMATCH[1]}"
-        fi
+          # If it's "lts/*", fetch "https://nodejs.org/download/release/index.json" and find the first version with "lts" not equal to false
+          # (We cannot run `nvm ls-remote --lts` because nvm is not yet installed)
+          if [[ "$NODE_VERSION" == "lts/*" ]]; then
+            NODE_VERSION=$(curl -s https://nodejs.org/download/release/index.json | jq -r '[.[] | select(.lts != false)][0].version')
+          fi
 
-        # If it's "lts/*", fetch "https://nodejs.org/download/release/index.json" and find the first version with "lts" not equal to false
-        # (We cannot run `nvm ls-remote --lts` because nvm is not yet installed)
-        if [[ "$NODE_VERSION" == "lts/*" ]]; then
-          NODE_VERSION=$(curl -s https://nodejs.org/download/release/index.json | jq -r '[.[] | select(.lts != false)][0].version')
-        fi
+          # Cut NODE_VERSION to the major and minor version (e.g. "v24.13")
+          NODE_VERSION=$(echo "$NODE_VERSION" | cut -d. -f1-2)
 
-        # Cut NODE_VERSION to the major and minor version (e.g. "v24.13")
-        NODE_VERSION=$(echo "$NODE_VERSION" | cut -d. -f1-2)
+          # Now make sure everything happened correctly: it starts with "v" and is in the format "vX.Y" or "vX".
+          if [[ "$NODE_VERSION" != v* || ! "$NODE_VERSION" =~ ^v[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "::error::Failed to determine Node.js version from .nvmrc or inputs.node-version. Version numbers are accepted with or without a 'v', and 'lts/*' is also accepted."
+            exit 1
+          fi
 
-        # Now make sure everything happened correctly: it starts with "v" and is in the format "vX.Y" or "vX".
-        if [[ "$NODE_VERSION" != v* || ! "$NODE_VERSION" =~ ^v[0-9]+(\.[0-9]+)?$ ]]; then
-          echo "::error::Failed to determine Node.js version from .nvmrc or inputs.node-version. Version numbers are accepted with or without a 'v', and 'lts/*' is also accepted."
-          exit 1
-        fi
-
-        echo "node-version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
-      shell: bash
+          echo "node-version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
       env:
         INPUT_NODE_VERSION: ${{ inputs.node-version }}
         OWNER_AND_REPO: ${{ github.repository }}
@@ -152,18 +154,21 @@ runs:
     - name: Download yarn.lock from current commit in attempt to skip setup
       if: ${{ inputs.is-high-risk-environment == 'false' && inputs.cache-node-modules == 'true' }}
       id: download-yarn-lock
-      run: |
-        if [[ ! -s yarn.lock ]]; then
-          YARN_LOCK_TMP_FILE="$(mktemp)"
-          if curl -sSf -o "$YARN_LOCK_TMP_FILE" "https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/yarn.lock"; then
-            # Only overwrite yarn.lock on a successful download.
-            mv "$YARN_LOCK_TMP_FILE" yarn.lock
-          else
-            rm -f "$YARN_LOCK_TMP_FILE"
-            echo "::warning::Failed to download yarn.lock from https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/yarn.lock"
-            exit 1
+      uses: MetaMask/action-retry-command@v1
+      with:
+        shell: bash
+        command: |
+          if [[ ! -s yarn.lock ]]; then
+            YARN_LOCK_TMP_FILE="$(mktemp)"
+            if curl -sSf -o "$YARN_LOCK_TMP_FILE" "https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/yarn.lock"; then
+              # Only overwrite yarn.lock on a successful download.
+              mv "$YARN_LOCK_TMP_FILE" yarn.lock
+            else
+              rm -f "$YARN_LOCK_TMP_FILE"
+              echo "::warning::Failed to download yarn.lock from https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/yarn.lock"
+              exit 1
+            fi
           fi
-        fi
       shell: bash
       continue-on-error: true
       env:

--- a/action.yml
+++ b/action.yml
@@ -205,6 +205,7 @@ runs:
       shell: bash
 
     - name: Remove globally installed Yarn
+      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' }}
       run: npm uninstall -g yarn
       shell: bash
 
@@ -258,7 +259,7 @@ runs:
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && steps.download-node-modules.outputs.cache-hit != 'true'}}
       uses: MetaMask/action-retry-command@v1
       with:
-        command: corepack yarn --immutable
+        command: yarn --immutable
         shell: bash
         max-retries: ${{ inputs.yarn-install-max-retries }}
 

--- a/action.yml
+++ b/action.yml
@@ -169,7 +169,6 @@ runs:
               exit 1
             fi
           fi
-      shell: bash
       continue-on-error: true
       env:
         OWNER_AND_REPO: ${{ github.repository }}

--- a/action.yml
+++ b/action.yml
@@ -254,7 +254,7 @@ runs:
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && steps.download-node-modules.outputs.cache-hit != 'true'}}
       uses: MetaMask/action-retry-command@v1
       with:
-        command: yarn --immutable
+        command: corepack yarn --immutable
         shell: bash
         max-retries: ${{ inputs.yarn-install-max-retries }}
 

--- a/action.yml
+++ b/action.yml
@@ -204,6 +204,11 @@ runs:
         echo "Using Node.js version: ${{ steps.setup-node.outputs.node-version }}"
       shell: bash
 
+    - name: Remove globally installed Yarn
+      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' }}
+      run: npm uninstall -g yarn
+      shell: bash
+
     - run: corepack enable
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' }}
       shell: bash
@@ -247,10 +252,6 @@ runs:
         #      restore the `node_modules` folder from cache, there's no need to
         #      download the `.yarn` folder too
         cache: 'yarn'
-
-    - name: Ensure Node is first in PATH
-      run: echo "$(dirname $(which node))" >> "$GITHUB_PATH"
-      shell: bash
 
     # If the node_modules cache was not found (or it's a high-risk environment),
     # run the yarn install


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the CI environment bootstrapping path; retries are low risk, but uninstalling global Yarn and changing download behavior could affect workflows that implicitly relied on a preinstalled Yarn or on immediate download failure semantics.
> 
> **Overview**
> Improves resiliency of the composite action by wrapping the `.nvmrc` and `yarn.lock` download steps with `MetaMask/action-retry-command@v1`, reducing flaky failures when fetching from `raw.githubusercontent.com`.
> 
> Also adds a setup step to `npm uninstall -g yarn` before `corepack enable`, ensuring the action uses the Corepack-managed Yarn rather than any globally installed Yarn when setup is not skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9073923128602d6163427e4fea3d2c448f1455e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->