### PR TITLE
feat: allow high-risk the option to save cache without reading cache

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -161,6 +161,48 @@ jobs:
         if: ${{ steps.checkout-and-setup.outputs.skipped-setup }}
         run: exit 1
 
+  test-high-risk-cache-write-only:
+    name: Test high-risk with cache (write-only mode)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Checkout and setup environment
+        id: checkout-and-setup
+        uses: ./
+        with:
+          is-high-risk-environment: true
+          cache-node-modules: true
+
+      - name: Ensure node_modules cache was not read
+        if: ${{ steps.checkout-and-setup.outputs.node-modules-cache-hit }}
+        run: exit 1
+
+      - name: Ensure .yarn cache was not used
+        if: ${{ steps.checkout-and-setup.outputs.yarn-cache-hit }}
+        run: exit 1
+
+  test-low-risk-reads-high-risk-cache:
+    name: Test low-risk reads high-risk cache
+    runs-on: ubuntu-latest
+    needs: test-high-risk-cache-write-only
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Checkout and setup environment
+        id: checkout-and-setup
+        uses: ./
+        with:
+          is-high-risk-environment: false
+
+      - name: Ensure node_modules cache was used
+        if: ${{ !steps.checkout-and-setup.outputs.node-modules-cache-hit }}
+        run: exit 1
+
+      - name: Ensure .yarn cache was not used
+        if: ${{ steps.checkout-and-setup.outputs.yarn-cache-hit }}
+        run: exit 1
+
   test-high-risk-string:
     name: Test high-risk string
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: ''
   cache-node-modules:
-    description: 'Enable caching for `node_modules`. Should only be enabled for the `prepare` job, and only applies when is-high-risk-environment is `false`.'
+    description: 'Enable node_modules caching for the prepare job. When is-high-risk-environment is true, only saves (write-only); when false, reads and writes.'
     required: false
     default: 'false'
   node-version:
@@ -65,9 +65,14 @@ runs:
     - name: Enforce required input is either "true" or "false"
       env:
         IS_HIGH_RISK_ENVIRONMENT: ${{ inputs.is-high-risk-environment }}
+        CACHE_NODE_MODULES: ${{ inputs.cache-node-modules }}
       run: |
         if [[ "$IS_HIGH_RISK_ENVIRONMENT" == "true" ]]; then
-          echo 'High-risk environment detected. Disabling cache for security.'
+          if [[ "$CACHE_NODE_MODULES" == "true" ]]; then
+            echo 'High-risk environment detected. Cache reads disabled; cache save enabled (write-only mode).'
+          else
+            echo 'High-risk environment detected. All caching disabled for security.'
+          fi
         elif [[ "$IS_HIGH_RISK_ENVIRONMENT" == "false" ]]; then
           echo 'Low-risk environment detected. Enabling cache for optimized performance.'
         else
@@ -262,10 +267,12 @@ runs:
           fi
         shell: bash
 
-    # Save the `node_modules` cache if it's not a high-risk environment and
-    # caching is enabled.
+    # Save the node_modules cache when caching is enabled.
+    # When is-high-risk-environment is true, the read steps above are skipped
+    # but we still save so that downstream PR jobs can read from the
+    # main-branch cache scope (write-only mode).
     - name: Cache workspace
-      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.is-high-risk-environment == 'false' && inputs.cache-node-modules == 'true' }}
+      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.cache-node-modules == 'true' }}
       uses: actions/cache/save@v5
       with:
         path: '**/node_modules'


### PR DESCRIPTION
This is a change in the action to allow writing to the cache without reading the cache.

This will allow us to implement this plan in metamask-extension:

- prep-deps, which writes to cache, should not be reading from cache on main and stable **<-- this is an increase in** security
- The build jobs and publish-prerelease, as they do right now on every branch, should not use cache on main and stable **<-- this is the status quo**
- Allow cache in every job on PRs **<-- this is a decrease in security, but a considerable speed gain**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI caching behavior in a security-sensitive context (high-risk vs low-risk), so misconfiguration could accidentally enable cache reads or leak cache across trust boundaries.
> 
> **Overview**
> Adds a *write-only caching mode* to the composite action: when `is-high-risk-environment: true` and `cache-node-modules: true`, cache **reads remain disabled** but the action will still **save** the `node_modules` cache for downstream low-risk jobs to consume.
> 
> Updates the action’s input documentation/logging to reflect the new behavior, and extends `build-lint-test.yml` with jobs that assert high-risk runs don’t hit `node_modules`/`.yarn` caches while a subsequent low-risk run can read the saved `node_modules` cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69d45c3948376f8e448ee9fa571a1a4fa6b6b202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->