### PR TITLE
Include Yarn install state when restoring cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -178,7 +178,7 @@ runs:
         path: |
           .yarn/install-state.gz
           **/node_modules
-        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('.yarn/install-state.gz', 'yarn.lock') }}
+        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
         lookup-only: true
 
     # Checkout repository only if not already checked out.
@@ -230,7 +230,7 @@ runs:
         path: |
           .yarn/install-state.gz
           **/node_modules
-        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('.yarn/install-state.gz', 'yarn.lock') }}
+        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
 
     - name: Conditionally restore action/setup-node cache
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.is-high-risk-environment != 'true' && steps.download-node-modules.outputs.cache-hit != 'true' }}
@@ -283,4 +283,4 @@ runs:
         path: |
           .yarn/install-state.gz
           **/node_modules
-        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('.yarn/install-state.gz', 'yarn.lock') }}
+        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}

--- a/action.yml
+++ b/action.yml
@@ -175,8 +175,10 @@ runs:
       id: try-skip-setup
       uses: actions/cache/restore@v5
       with:
-        path: '**/node_modules'
-        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
+        path: |
+          .yarn/install-state.gz
+          **/node_modules
+        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('.yarn/install-state.gz', 'yarn.lock') }}
         lookup-only: true
 
     # Checkout repository only if not already checked out.
@@ -217,15 +219,18 @@ runs:
       env:
         YARN_TARBALL: ${{ inputs.yarn-tarball }}
 
-    # In a low-risk environment, try to download cache of `node_modules`, if it
-    # exists. On failure, will run the `yarn` command instead.
-    - name: Download node_modules cache
+    # In a low-risk environment, try to download cache of `node_modules` and
+    # Yarn install state, if they exist. On failure, will run the `yarn`
+    # command instead.
+    - name: Download node_modules cache and Yarn install state
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.is-high-risk-environment == 'false' }}
       id: download-node-modules
       uses: actions/cache/restore@v5
       with:
-        path: '**/node_modules'
-        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
+        path: |
+          .yarn/install-state.gz
+          **/node_modules
+        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('.yarn/install-state.gz', 'yarn.lock') }}
 
     - name: Conditionally restore action/setup-node cache
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.is-high-risk-environment != 'true' && steps.download-node-modules.outputs.cache-hit != 'true' }}
@@ -275,5 +280,7 @@ runs:
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.cache-node-modules == 'true' }}
       uses: actions/cache/save@v5
       with:
-        path: '**/node_modules'
-        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
+        path: |
+          .yarn/install-state.gz
+          **/node_modules
+        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('.yarn/install-state.gz', 'yarn.lock') }}


### PR DESCRIPTION
## Description

Both clients use a bespoke Yarn plugin for installing preview builds, which are prerelease versions of libraries that engineers can generate and use. This plugin works by modifying Yarn resolutions in memory in order to map packages from the `@metamask` NPM scope to a special version within the `@metamask-previews` scope.

In the extension, we have found that this plugin does not seem to work in CI. More specifically, if one job runs this workflow and caches `node_modules`, when another job runs this workflow again to restore `node_modules` from cache, attempting to run a Yarn command fails (the preview build is not found). Caching `node_modules` does not seem to be sufficient to restore the mapping of resolutions that the plugin needs to work correctly. We need to also cache and restore `.yarn/install-state.gz`.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## References

See this Slack thread for more information: https://consensys.slack.com/archives/C094GV3E7SB/p1777056238889789

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared composite GitHub Action used for dependency setup/caching, so any mistake can impact CI reliability and cache behavior across repos. Change is straightforward (adds one file to cache paths) with low security/data risk.
> 
> **Overview**
> Ensures Yarn’s install metadata is preserved across CI runs by caching/restoring `.yarn/install-state.gz` alongside `**/node_modules` in all workspace cache restore/save steps (including the fast “skip setup” lookup).
> 
> Updates the related step name/comment to reflect that both `node_modules` and Yarn install state are now restored, improving reliability for workflows that depend on Yarn’s internal resolution state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4346cce7fa7e06aa4561bddc126cf93f843dd38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->