### PR TITLE
Add option to control whether setup-node is used for cache fallback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Force the setup steps to run, even if a cache hit occurs. This is useful in cases where you need to run more steps after setup.'
     required: false
     default: 'false'
+  use-setup-node-for-cache-fallback:
+    description: 'Attempt to restore cache via actions/setup-node if not found otherwise'
+    required: false
+    default: 'true'
 
 # The outputs are for the unit tests in `build-lint-test.yml`, and
 # probably not useful for other workflows.
@@ -228,7 +232,7 @@ runs:
         key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
 
     - name: Conditionally restore action/setup-node cache
-      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.is-high-risk-environment != 'true' && steps.download-node-modules.outputs.cache-hit != 'true' }}
+      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.is-high-risk-environment != 'true' && steps.download-node-modules.outputs.cache-hit != 'true' && inputs.use-setup-node-for-cache-fallback != 'false' }}
       uses: actions/setup-node@v6
       id: restore-setup-node-cache
       with:


### PR DESCRIPTION
## Description

Currently, this action uses two strategies for caching `node_modules`. It will first attempt to restore a previous cache, and if there is a cache miss, the action will fall back to `actions/setup-node` and its cache.

Here's we've observed in other repos such as the extension: if `yarn.lock` is updated in a PR, the first job to run this action will correctly see a cache miss (since the cache key is based on the contents of `yarn.lock`). However, `actions/setup-node` may report a cache *hit*. That is very strange, because its cache key is supposedly _also_ based on the contents of `yarn.lock` — except even stranger, the hash of `yarn.lock` that `setup-node` computes is different from the one that this action computes.

We haven't been able to nail down the exact differences between this action and `actions/setup-node` that would cause this behavior. Regardless, it may not be necessary to fall back to `actions/setup-node` for cache restoration. Therefore, this commit adds an option so that the fallback can be disabled.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## References

See this Slack thread for more information: https://consensys.slack.com/archives/C094GV3E7SB/p1777056238889789

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a new optional input that gates an existing cache-restore step, changing behavior only when explicitly disabled.
> 
> **Overview**
> Adds a new `use-setup-node-for-cache-fallback` input (default `true`) to control whether the action falls back to `actions/setup-node`’s Yarn cache restore when the `node_modules` cache is missed.
> 
> When set to `false`, the `Conditionally restore action/setup-node cache` step is skipped, preventing `setup-node` from restoring `.yarn` as a secondary cache source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ddb11aaa0eb137e2c807148d60952af28791014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->