### PR TITLE
fix: Support private repositories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
             NVMRC_TMP_FILE="$(mktemp)"
             if gh api "repos/${OWNER_AND_REPO}/contents/.nvmrc?ref=${COMMIT_HASH}" \
               --header "Accept: application/vnd.github.raw+json" \
-              --output "$NVMRC_TMP_FILE"; then
+              > "$NVMRC_TMP_FILE"; then
               mv "$NVMRC_TMP_FILE" .nvmrc
             else
               rm -f "$NVMRC_TMP_FILE"
@@ -160,7 +160,7 @@ runs:
           YARN_LOCK_TMP_FILE="$(mktemp)"
           if gh api "repos/${OWNER_AND_REPO}/contents/yarn.lock?ref=${COMMIT_HASH}" \
             --header "Accept: application/vnd.github.raw+json" \
-            --output "$YARN_LOCK_TMP_FILE"; then
+            > "$YARN_LOCK_TMP_FILE"; then
             # Only overwrite yarn.lock on a successful download.
             mv "$YARN_LOCK_TMP_FILE" yarn.lock
           else

--- a/action.yml
+++ b/action.yml
@@ -88,11 +88,13 @@ runs:
         if [[ -z "$INPUT_NODE_VERSION" ]]; then
           if [[ ! -s .nvmrc ]]; then
             NVMRC_TMP_FILE="$(mktemp)"
-            if curl -sSf -o "$NVMRC_TMP_FILE" "https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/.nvmrc"; then
+            if gh api "repos/${OWNER_AND_REPO}/contents/.nvmrc?ref=${COMMIT_HASH}" \
+              --header "Accept: application/vnd.github.raw+json" \
+              --output "$NVMRC_TMP_FILE"; then
               mv "$NVMRC_TMP_FILE" .nvmrc
             else
               rm -f "$NVMRC_TMP_FILE"
-              echo "::error::You must either have a .nvmrc at the requested ref, or provide the node-version input. Failed to download .nvmrc from https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/.nvmrc"
+              echo "::error::You must either have a .nvmrc at the requested ref, or provide the node-version input. Failed to download .nvmrc from ${OWNER_AND_REPO}@${COMMIT_HASH}"
               exit 1
             fi
           fi
@@ -145,6 +147,7 @@ runs:
         echo "node-version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
       shell: bash
       env:
+        GH_TOKEN: ${{ github.token }}
         INPUT_NODE_VERSION: ${{ inputs.node-version }}
         OWNER_AND_REPO: ${{ github.repository }}
         COMMIT_HASH: ${{ inputs.ref || github.sha }}
@@ -155,18 +158,21 @@ runs:
       run: |
         if [[ ! -s yarn.lock ]]; then
           YARN_LOCK_TMP_FILE="$(mktemp)"
-          if curl -sSf -o "$YARN_LOCK_TMP_FILE" "https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/yarn.lock"; then
+          if gh api "repos/${OWNER_AND_REPO}/contents/yarn.lock?ref=${COMMIT_HASH}" \
+            --header "Accept: application/vnd.github.raw+json" \
+            --output "$YARN_LOCK_TMP_FILE"; then
             # Only overwrite yarn.lock on a successful download.
             mv "$YARN_LOCK_TMP_FILE" yarn.lock
           else
             rm -f "$YARN_LOCK_TMP_FILE"
-            echo "::warning::Failed to download yarn.lock from https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/yarn.lock"
+            echo "::warning::Failed to download yarn.lock from ${OWNER_AND_REPO}@${COMMIT_HASH}"
             exit 1
           fi
         fi
       shell: bash
       continue-on-error: true
       env:
+        GH_TOKEN: ${{ github.token }}
         OWNER_AND_REPO: ${{ github.repository }}
         COMMIT_HASH: ${{ inputs.ref || github.sha }}
 


### PR DESCRIPTION
## Summary

- Replace `curl` with `gh api` when downloading `.nvmrc` and `yarn.lock` from GitHub, so that downloads work for private repositories as well.
- Add `GH_TOKEN: ${{ github.token }}` to the relevant steps to authenticate the `gh` CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to how two files are downloaded during CI setup; uses the standard workflow token and does not change install or caching logic.
> 
> **Overview**
> Fixes composite action setup when the repo is **private** by fetching `.nvmrc` and `yarn.lock` through the **GitHub Contents API** with `gh api` instead of unauthenticated `raw.githubusercontent.com` URLs.
> 
> Both the **compute-node-version** and **download-yarn-lock** steps now set `GH_TOKEN: ${{ github.token }}` so `gh` can read repo contents at the requested ref. Failure/warning messages were updated to reference `owner/repo@ref` instead of the old raw URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d0059c68d2d22acc6edddb6ad294d1b83ce47c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->