### PR TITLE
feat: Add `persist-credentials` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Force the setup steps to run, even if a cache hit occurs. This is useful in cases where you need to run more steps after setup.'
     required: false
     default: 'false'
+  persist-credentials:
+    description: 'Whether to persist the GitHub token in the checked-out repository. This is passed to the `actions/checkout` step. Setting this to false can help prevent accidental token leaks, but if your workflow needs to make authenticated GitHub API calls using the checked-out repository, you may need to set this to true (default).'
+    required: false
+    default: 'true'
 
 # The outputs are for the unit tests in `build-lint-test.yml`, and
 # probably not useful for other workflows.
@@ -194,6 +198,7 @@ runs:
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         ref: ${{ inputs.ref }}
+        persist-credentials: ${{ inputs.persist-credentials }}
 
     - name: Set up Node.js
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
## Summary

- Adds a `persist-credentials` input passed through to the `actions/checkout` step.
- Defaults to `true` to preserve existing behaviour.
- Setting to `false` prevents accidental GitHub token leaks in workflows that don't need authenticated Git operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible composite-action input with default `true`; only affects checkout credential persistence when callers opt out.
> 
> **Overview**
> Adds a **`persist-credentials`** action input (default **`true`**) and forwards it to the conditional **`actions/checkout`** step so callers can disable storing the GitHub token in the repo’s git config.
> 
> Setting **`persist-credentials: false`** is intended to reduce accidental token exposure in workflows that do not need authenticated git operations after checkout; workflows that rely on the checked-out repo for authenticated GitHub API calls can keep the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a07bfa741091fadd3de7fa38dba97917eb22e56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->