### PR TITLE
fix: Use environment variable for Node.js version in echo command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -210,8 +210,10 @@ runs:
     - name: Print Node.js version
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' }}
       run: |
-        echo "Using Node.js version: ${{ steps.setup-node.outputs.node-version }}"
+        echo "Using Node.js version: $NODE_VERSION"
       shell: bash
+      env:
+        NODE_VERSION: ${{ steps.setup-node.outputs.node-version }}
 
     - run: corepack enable
       if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
The "Print Node.js version" step interpolates the node version directly into the shell command via `${{ ... }}`, which is a GitHub Actions expression injection anti-pattern.

This changes it to pass the value through an `env` variable instead, which is the recommended safe approach.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no behavior or security surface beyond avoiding expression injection in one echo step.
> 
> **Overview**
> The **Print Node.js version** step no longer embeds `${{ steps.setup-node.outputs.node-version }}` in the `run` script. It sets **`NODE_VERSION`** in `env` and echoes `$NODE_VERSION` in bash, matching GitHub’s guidance to avoid expression injection in shell steps.
> 
> Logged output is unchanged; only how the version is passed into the shell differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741aae00c723e179ef17428241d90a59c862b9b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->