### PR TITLE
feat: Add `skip-install` input

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -295,6 +295,32 @@ jobs:
         if: ${{ !contains(steps.checkout-and-setup.outputs.node-version, '20.') }}
         run: node --version && exit 1
 
+  test-skip-install:
+    name: Test skip-install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout and setup environment
+        id: checkout-and-setup
+        uses: ./
+        with:
+          is-high-risk-environment: false
+          skip-install: true
+
+      - name: Ensure Node.js was set up
+        if: ${{ !steps.checkout-and-setup.outputs.node-version }}
+        run: exit 1
+
+      - name: Ensure dependencies were not installed
+        run: |
+          if [ -d node_modules ]; then
+            echo "node_modules should not exist when skip-install is true"
+            exit 1
+          fi
+
+      - name: Ensure caches were not used
+        if: ${{ steps.checkout-and-setup.outputs.node-modules-cache-hit || steps.checkout-and-setup.outputs.yarn-cache-hit }}
+        run: exit 1
+
   test-do-not-checkout-twice:
     name: Test do not checkout twice
     runs-on: ubuntu-latest

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -299,6 +299,8 @@ jobs:
     name: Test skip-install
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
       - name: Checkout and setup environment
         id: checkout-and-setup
         uses: ./

--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ Defaults to `false`.
 If set to `true`, the action will skip the cache and force the setup steps to
 run. This is useful for ensuring that the environment is set up correctly, even if there is a cache hit.
 
+#### `skip-install`
+
+If set to `true`, the action will skip all Yarn install steps. The repository
+is still checked out and Node.js is still set up, but dependencies are not
+installed. This is useful when your workflow only needs Node.js available and
+manages its own dependency installation.
+
+Defaults to `false`.
+
 ## Contributing
 
 ### Setup

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: 'Whether to persist the GitHub token in the checked-out repository. This is passed to the `actions/checkout` step. Setting this to false can help prevent accidental token leaks, but if your workflow needs to make authenticated GitHub API calls using the checked-out repository, you may need to set this to true (default).'
     required: false
     default: 'true'
+  skip-install:
+    description: 'Skip all Yarn install steps. The repository is still checked out and Node.js is still set up, but dependencies are not installed.'
+    required: false
+    default: 'false'
 
 # The outputs are for the unit tests in `build-lint-test.yml`, and
 # probably not useful for other workflows.
@@ -168,7 +172,7 @@ runs:
         REPO_VISIBILITY: ${{ github.event.repository.visibility }}
 
     - name: Download yarn.lock from current commit in attempt to skip setup
-      if: ${{ inputs.is-high-risk-environment == 'false' && inputs.cache-node-modules == 'true' }}
+      if: ${{ inputs.is-high-risk-environment == 'false' && inputs.cache-node-modules == 'true' && inputs.skip-install != 'true' }}
       id: download-yarn-lock
       run: |
         if [[ ! -s yarn.lock ]]; then
@@ -203,7 +207,7 @@ runs:
         REPO_VISIBILITY: ${{ github.event.repository.visibility }}
 
     - name: Try skipping setup if node-modules cache available
-      if: ${{ inputs.is-high-risk-environment == 'false' && inputs.cache-node-modules == 'true' && steps.download-yarn-lock.outcome == 'success' && inputs.force-setup != 'true' }}
+      if: ${{ inputs.is-high-risk-environment == 'false' && inputs.cache-node-modules == 'true' && steps.download-yarn-lock.outcome == 'success' && inputs.force-setup != 'true' && inputs.skip-install != 'true' }}
       id: try-skip-setup
       uses: actions/cache/restore@v5
       with:
@@ -258,7 +262,7 @@ runs:
     # Yarn install state, if they exist. On failure, will run the `yarn`
     # command instead.
     - name: Download node_modules cache and Yarn install state
-      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.is-high-risk-environment == 'false' }}
+      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.is-high-risk-environment == 'false' && inputs.skip-install != 'true' }}
       id: download-node-modules
       uses: actions/cache/restore@v5
       with:
@@ -268,7 +272,7 @@ runs:
         key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
 
     - name: Conditionally restore action/setup-node cache
-      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.is-high-risk-environment != 'true' && steps.download-node-modules.outputs.cache-hit != 'true' }}
+      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.is-high-risk-environment != 'true' && steps.download-node-modules.outputs.cache-hit != 'true' && inputs.skip-install != 'true' }}
       uses: actions/setup-node@v6
       id: restore-setup-node-cache
       with:
@@ -287,7 +291,7 @@ runs:
     # If the node_modules cache was not found (or it's a high-risk environment),
     # run the yarn install
     - name: Install dependencies
-      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && steps.download-node-modules.outputs.cache-hit != 'true'}}
+      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && steps.download-node-modules.outputs.cache-hit != 'true' && inputs.skip-install != 'true' }}
       uses: MetaMask/action-retry-command@v1
       with:
         command: yarn --immutable
@@ -298,7 +302,7 @@ runs:
     # typically run as part of the Yarn install, so we only need to run it if
     # we're restoring the cache.
     - name: Run `allow-scripts`
-      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.skip-allow-scripts != 'true' && steps.download-node-modules.outputs.cache-hit == 'true'}}
+      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.skip-allow-scripts != 'true' && steps.download-node-modules.outputs.cache-hit == 'true' && inputs.skip-install != 'true' }}
       uses: MetaMask/action-retry-command@v1
       with:
         command: |
@@ -312,7 +316,7 @@ runs:
     # but we still save so that downstream PR jobs can read from the
     # main-branch cache scope (write-only mode).
     - name: Cache workspace
-      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.cache-node-modules == 'true' }}
+      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.cache-node-modules == 'true' && inputs.skip-install != 'true' }}
       uses: actions/cache/save@v5
       with:
         path: |


### PR DESCRIPTION
## Explanation

The action currently always runs `yarn install` (and surrounding cache lookups) as part of its setup. There are workflows that only need the repository checked out and Node.js available — for example, publishing to npm, where Node.js is required to run the publish action but installing the package's dependencies is undesirable from a supply-chain-security perspective. For those workflows, the install step is both wasted time and unnecessary attack surface.

This adds a new `skip-install` input (default `false`). When set to `true`, the action still performs the checkout and Node.js setup (including `corepack enable` and yarn hydration, so `yarn` itself is available), but skips:

- The yarn.lock download and `try-skip-setup` cache lookup
- The `node_modules` cache restore
- The setup-node yarn cache restore
- `yarn --immutable`
- `yarn allow-scripts`
- The post-install cache save

A new `test-skip-install` job in `build-lint-test.yml` exercises the new path and asserts that Node.js is set up, `node_modules` is absent, and no caches were consulted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in CI behavior change with default unchanged; reduces install surface when enabled rather than altering existing install paths.
> 
> **Overview**
> Adds a **`skip-install`** action input (default `false`) so workflows can get checkout + Node.js (and Corepack/Yarn hydration) without installing dependencies or touching install caches.
> 
> When **`skip-install: true`**, the composite action skips yarn.lock prefetch, node_modules cache lookup/restore/save, setup-node yarn cache, **`yarn --immutable`**, and **`yarn allow-scripts`**. README documents the option; **`test-skip-install`** in CI asserts Node is configured, **`node_modules`** is absent, and cache outputs are not hit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 640ad34765578ff2a9fd1d3bf94ebb59b0d3602d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->