### PR TITLE
ci: cache only the root node_modules

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -213,7 +213,7 @@ runs:
       with:
         path: |
           .yarn/install-state.gz
-          **/node_modules
+          node_modules
         key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
         lookup-only: true
 
@@ -268,7 +268,7 @@ runs:
       with:
         path: |
           .yarn/install-state.gz
-          **/node_modules
+          node_modules
         key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
 
     - name: Conditionally restore action/setup-node cache
@@ -321,5 +321,5 @@ runs:
       with:
         path: |
           .yarn/install-state.gz
-          **/node_modules
+          node_modules
         key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
Cache only the root `node_modules` directory instead of using the recursive `**/node_modules` glob.

Previously, the cache path matched hundreds of nested `node_modules` directories inside the root install tree. That did not meaningfully improve what was cached, because those directories were already contained under the root `node_modules`, but it made `actions/cache` spend a long time building the cache manifest before `tar` could even start.

With the new path, the cache still captures the installed dependencies, but `actions/cache` only has to walk the root cache path once.

In paired cold `node_modules` runs on `metamask-extension` with the Yarn package cache warm:

- old path: about `46s` to save the `node_modules` cache, including about `29s` before `tar` started
- new path: about `17s` to save the cache, with `tar` starting immediately

That makes `Prepare dependencies` about `23s` faster in the clean paired run, and removes roughly `30s` of cache-save overhead from cold `node_modules` cache misses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrower cache paths only; same cache key and `.yarn/install-state.gz` pairing, with no auth or install logic changes.
> 
> **Overview**
> **Speeds up `Prepare dependencies` on cold `node_modules` cache misses** by narrowing what `actions/cache` restores and saves.
> 
> All three `node_modules` cache steps (`try-skip-setup`, `download-node-modules`, and `Cache workspace`) now use `node_modules` instead of `**/node_modules`. Dependencies are still covered because nested installs live under the root tree; the recursive glob was forcing the action to walk hundreds of paths and build a large manifest before `tar` ran.
> 
> Reported impact on `metamask-extension` (Yarn package cache warm): cache save dropped from ~46s (~29s pre-`tar`) to ~17s with `tar` starting immediately—roughly **23s** faster `Prepare dependencies` and **~30s** less overhead on cache misses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ddd894bd99eee29abbe1d2550c5d2d364e39b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->