### PR TITLE
Revert "3.4.1"

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-      - run: corepack enable
       - uses: MetaMask/action-create-release-pr@v5
         with:
           release-type: ${{ github.event.inputs.release-type }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,38 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.4.1]
-
-### Changed
-
-- bump: update everything to the latest versions (#76)
-- ci: cache only the root node_modules (#78)
-
 ## [3.4.0]
 
 ### Added
 
-- Add `skip-install` input (#74)
+- Add `skip-install` input ([#74](https://github.com/MetaMask/action-checkout-and-setup/pull/74))
   - This option can be used to skip installing Yarn dependencies, useful for when Node.js setup is needed, but dependencies are not.
 
 ## [3.3.1]
 
 ### Fixed
 
-- Use raw GitHub URL for public repositories (#72)
+- Use raw GitHub URL for public repositories ([#72](https://github.com/MetaMask/action-checkout-and-setup/pull/72))
   - This solves an issue with rate limit errors caused by using the GitHub API in high-activity public repositories.
 
 ## [3.3.0]
 
 ### Added
 
-- Add `persist-credentials` input (#69)
+- Add `persist-credentials` input ([#69](https://github.com/MetaMask/action-checkout-and-setup/pull/69))
   - This is forwarded to `actions/checkout`, and defaults to `false`.
 
 ### Fixed
 
-- Restore support for private repositories (#68)
-- Include Yarn install state when restoring cache (#66)
+- Restore support for private repositories ([#68](https://github.com/MetaMask/action-checkout-and-setup/pull/68))
+- Include Yarn install state when restoring cache ([#66](https://github.com/MetaMask/action-checkout-and-setup/pull/66))
 
 ## [3.2.0]
 
@@ -50,13 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `force-setup` option to always perform checkout and setup (#61)
+- Add `force-setup` option to always perform checkout and setup ([#61](https://github.com/MetaMask/action-checkout-and-setup/pull/61))
 
 ## [3.0.1]
 
 ### Fixed
 
-- Fix Windows runner compatibility by using `curl` instead of `wget` (#59)
+- Fix Windows runner compatibility by using `curl` instead of `wget` ([#59](https://github.com/MetaMask/action-checkout-and-setup/pull/59))
 
 ## [3.0.0]
 
@@ -69,75 +62,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Use environment variables for script inputs (#44)
+- Use environment variables for script inputs ([#44](https://github.com/MetaMask/action-checkout-and-setup/pull/44))
 
 ## [2.0.0]
 
 ### Changed
 
-- **BREAKING**: Bump `GitHub/actions/*` actions to latest versions (#41)
-- **BREAKING**: Always include runner OS and arch in cache key (#40)
-- **BREAKING**: Include full Node version in cache key (#38)
+- **BREAKING**: Bump `GitHub/actions/*` actions to latest versions ([#41](https://github.com/MetaMask/action-checkout-and-setup/pull/41))
+- **BREAKING**: Always include runner OS and arch in cache key ([#40](https://github.com/MetaMask/action-checkout-and-setup/pull/40))
+- **BREAKING**: Include full Node version in cache key ([#38](https://github.com/MetaMask/action-checkout-and-setup/pull/38))
 
 ## [1.4.0]
 
 ### Added
 
-- Add parameter for platform specific caching (#34)
+- Add parameter for platform specific caching ([#34](https://github.com/MetaMask/action-checkout-and-setup/pull/34))
   - By default the cache is not platform specific, meaning the same cache is used by different operating systems.
   - The new behaviour can be enabled by setting `platform-specific-caching` to `true`.
 
 ### Changed
 
-- Use more efficient cache key (#33)
+- Use more efficient cache key ([#33](https://github.com/MetaMask/action-checkout-and-setup/pull/33))
 
 ## [1.3.0]
 
 ### Added
 
-- Allow to use a local stored yarn binary (#28, #30)
+- Allow to use a local stored yarn binary ([#28](https://github.com/MetaMask/action-checkout-and-setup/pull/28), [#30](https://github.com/MetaMask/action-checkout-and-setup/pull/30))
 
 ## [1.2.0]
 
 ### Added
 
-- Add `yarn-custom-url` and `yarn-install-max-retries` options (#24)
+- Add `yarn-custom-url` and `yarn-install-max-retries` options ([#24](https://github.com/MetaMask/action-checkout-and-setup/pull/24))
 
 ## [1.1.1]
 
 ### Fixed
 
-- Cache nested `node_modules` directories (#20)
+- Cache nested `node_modules` directories ([#20](https://github.com/MetaMask/action-checkout-and-setup/pull/20))
 
 ## [1.1.0]
 
 ### Added
 
-- Add `skip-allow-scripts` option (#14)
+- Add `skip-allow-scripts` option ([#14](https://github.com/MetaMask/action-checkout-and-setup/pull/14))
   - This can speed up the action by skipping the `allow-scripts` step, if it's not required.
 
 ### Changed
 
-- Use `MetaMask/action-retry-command` for possible flaky steps (#16)
+- Use `MetaMask/action-retry-command` for possible flaky steps ([#16](https://github.com/MetaMask/action-checkout-and-setup/pull/16))
 
 ### Fixed
 
-- Use current commit hash for cache key instead of `github.sha` (#15)
+- Use current commit hash for cache key instead of `github.sha` ([#15](https://github.com/MetaMask/action-checkout-and-setup/pull/15))
 
 ## [1.0.1]
 
 ### Fixed
 
-- Run `allow-scripts` when restoring from cache (#11)
+- Run `allow-scripts` when restoring from cache ([#11](https://github.com/MetaMask/action-checkout-and-setup/pull/11))
 
 ## [1.0.0]
 
 ### Added
 
-- Initial release of `MetaMask/action-checkout-and-setup` (#9)
+- Initial release of `MetaMask/action-checkout-and-setup` ([#9](https://github.com/MetaMask/action-checkout-and-setup/pull/9))
 
-[Unreleased]: https://github.com/MetaMask/action-checkout-and-setup/compare/v3.4.1...HEAD
-[3.4.1]: https://github.com/MetaMask/action-checkout-and-setup/compare/v3.4.0...v3.4.1
+[Unreleased]: https://github.com/MetaMask/action-checkout-and-setup/compare/v3.4.0...HEAD
 [3.4.0]: https://github.com/MetaMask/action-checkout-and-setup/compare/v3.3.1...v3.4.0
 [3.3.1]: https://github.com/MetaMask/action-checkout-and-setup/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/MetaMask/action-checkout-and-setup/compare/v3.2.0...v3.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/action-checkout-and-setup",
-  "version": "3.4.1",
+  "version": "3.4.0",
   "private": true,
   "description": "Checkout repository and set up a Node.js environment with a reusable GitHub Action",
   "homepage": "https://github.com/MetaMask/action-checkout-and-setup#readme",


### PR DESCRIPTION
Reverts MetaMask/action-checkout-and-setup#77.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, version metadata, and a non-runtime CI workflow step only; no changes to the composite action’s runtime behavior.
> 
> **Overview**
> Reverts **#77** and restores the repo to the **3.4.0** release state.
> 
> `package.json` version is set back from `3.4.1` to `3.4.0`. The **3.4.1** changelog section (dependency bumps and CI cache tweak) is removed, and the `[Unreleased]` compare link again points at `v3.4.0`. Several historical changelog bullets revert from full PR URLs to shorter `(#NN)` references.
> 
> In **create-release-pr**, the **`corepack enable`** step after Node setup is removed again (the main action still runs `corepack enable` in `action.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf36f4505fac74a7848af5939fdb6eba894f0f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->