### PR TITLE
feat: better and faster monorepo support

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
+      - run: corepack enable
       - uses: MetaMask/action-create-release-pr@v5
         with:
           release-type: ${{ github.event.inputs.release-type }}

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ Defaults to the current ref.
 
 #### `cache-node-modules`
 
-If set to `true`, the action will cache the `node_modules` directory. This
-should only be enabled for a "prepare"-type job. This cannot be enabled in a
-high-risk environment.
+If set to `true`, the action will cache Yarn install state, the root
+`node_modules` directory, and any workspace-level `node_modules` directories
+derived from the root `package.json` `workspaces` field. This should only be
+enabled for a "prepare"-type job. In a high-risk environment, cache reads are
+disabled and this option only saves a cache for downstream low-risk jobs.
 
 Defaults to `false`.
 
@@ -119,8 +121,14 @@ Defaults to `false`.
 
 #### `force-setup`
 
-If set to `true`, the action will skip the cache and force the setup steps to
-run. This is useful for ensuring that the environment is set up correctly, even if there is a cache hit.
+If set to `true`, the action will force checkout, Node setup, and cache restore
+to run even if the `node_modules` cache exists. This is useful with
+`cache-node-modules: true` when later steps in the same job need a prepared
+workspace, for example to run `yarn` commands, inspect checked-out files, or
+publish outputs derived from the repository.
+
+Leave this as `false` only for cache-warming jobs where the job can safely end
+after confirming that the cache already exists.
 
 #### `skip-install`
 

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
     default: '.yarn/yarn-corepack.tgz'
   force-setup:
-    description: 'Force the setup steps to run, even if a cache hit occurs. This is useful in cases where you need to run more steps after setup.'
+    description: 'Force checkout, Node setup, and cache restore to run even if the node_modules cache exists. Use this with cache-node-modules when later steps in the same job need a prepared workspace.'
     required: false
     default: 'false'
   persist-credentials:
@@ -89,35 +89,112 @@ runs:
         fi
       shell: bash
 
+    - name: Download repository metadata from current commit
+      id: download-repository-metadata
+      run: |
+        # Some decisions in this action happen before actions/checkout runs:
+        # choosing a Node.js version, computing cache keys, and deciding whether
+        # a lookup-only node_modules cache hit can skip setup. Download only the
+        # small metadata files those decisions need instead of checking out the
+        # repository early.
+        METADATA_DIR="$RUNNER_TEMP/action-checkout-and-setup-metadata"
+        mkdir -p "$METADATA_DIR"
+
+        download_file() {
+          local file_path="$1"
+          local destination="$2"
+
+          if [[ -s "$destination" ]]; then
+            return 0
+          fi
+
+          # For public repositories, we can download the raw file directly from
+          # the GitHub URL. For private repositories, we need to use the GitHub
+          # CLI to authenticate and download the file. We don't use the GitHub
+          # CLI for public repositories because it's subject to the GitHub REST
+          # API rate limit, while the raw URL is served by a CDN that is not.
+          if [[ "$REPO_VISIBILITY" == "public" ]]; then
+            curl -sSf -o "$destination" "https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/${file_path}"
+          else
+            gh api "repos/${OWNER_AND_REPO}/contents/${file_path}?ref=${COMMIT_HASH}" --header "Accept: application/vnd.github.raw+json" > "$destination"
+          fi
+        }
+
+        write_output() {
+          echo "$1=$2" >> "$GITHUB_OUTPUT"
+        }
+
+        NVMRC_PATH=""
+        if [[ -s .nvmrc ]]; then
+          NVMRC_PATH=".nvmrc"
+        elif [[ -z "$INPUT_NODE_VERSION" ]]; then
+          # .nvmrc is required only when the caller did not provide node-version.
+          # If we cannot find it locally or at the requested ref, setup-node
+          # cannot be configured correctly, so this failure is fatal.
+          NVMRC_PATH="$METADATA_DIR/.nvmrc"
+          if ! download_file ".nvmrc" "$NVMRC_PATH"; then
+            rm -f "$NVMRC_PATH"
+            echo "::error::You must either have a .nvmrc at the requested ref, or provide the node-version input. Failed to download .nvmrc from ${OWNER_AND_REPO}@${COMMIT_HASH}"
+            exit 1
+          fi
+        fi
+        write_output "nvmrc-path" "$NVMRC_PATH"
+
+        YARN_LOCK_AVAILABLE="false"
+        if [[ -s yarn.lock ]]; then
+          YARN_LOCK_AVAILABLE="true"
+        elif [[ "$IS_HIGH_RISK_ENVIRONMENT" == "false" && "$CACHE_NODE_MODULES" == "true" && "$SKIP_INSTALL" != "true" ]]; then
+          # hashFiles('yarn.lock') can only see files in the workspace, so keep
+          # this download in place instead of the metadata directory. A missing
+          # yarn.lock just disables the lookup-only cache check; the normal
+          # checkout/setup path can still continue.
+          if download_file "yarn.lock" "yarn.lock"; then
+            YARN_LOCK_AVAILABLE="true"
+          else
+            rm -f yarn.lock
+            echo "::warning::Failed to download yarn.lock from ${OWNER_AND_REPO}@${COMMIT_HASH}"
+          fi
+        fi
+        write_output "yarn-lock-available" "$YARN_LOCK_AVAILABLE"
+
+        PACKAGE_JSON_PATH=""
+        if [[ -s package.json ]]; then
+          PACKAGE_JSON_PATH="package.json"
+        elif [[ "$SKIP_INSTALL" != "true" && ( "$IS_HIGH_RISK_ENVIRONMENT" == "false" || "$CACHE_NODE_MODULES" == "true" ) ]]; then
+          # package.json lets us derive shallow workspace node_modules paths
+          # before checkout. This avoids the expensive **/node_modules manifest
+          # walk when saving/restoring the cache. If it is unavailable, we fall
+          # back later to the broad path so the action remains compatible.
+          PACKAGE_JSON_PATH="$METADATA_DIR/package.json"
+          if ! download_file "package.json" "$PACKAGE_JSON_PATH"; then
+            rm -f "$PACKAGE_JSON_PATH"
+            PACKAGE_JSON_PATH=""
+            echo "::warning::Failed to download package.json from ${OWNER_AND_REPO}@${COMMIT_HASH}; using the broad node_modules cache path fallback."
+          fi
+        fi
+        write_output "package-json-path" "$PACKAGE_JSON_PATH"
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        CACHE_NODE_MODULES: ${{ inputs.cache-node-modules }}
+        INPUT_NODE_VERSION: ${{ inputs.node-version }}
+        IS_HIGH_RISK_ENVIRONMENT: ${{ inputs.is-high-risk-environment }}
+        OWNER_AND_REPO: ${{ github.repository }}
+        COMMIT_HASH: ${{ inputs.ref || github.sha }}
+        REPO_VISIBILITY: ${{ github.event.repository.visibility }}
+        SKIP_INSTALL: ${{ inputs.skip-install }}
+
     - name: Synthesize our node version from inputs.node-version and .nvmrc
       id: compute-node-version
       run: |
         # If inputs.node-version is not provided then use .nvmrc
         if [[ -z "$INPUT_NODE_VERSION" ]]; then
-          if [[ ! -s .nvmrc ]]; then
-            NVMRC_TMP_FILE="$(mktemp)"
-
-            # For public repositories, we can download the raw file directly from
-            # the GitHub URL. For private repositories, we need to use the GitHub
-            # CLI to authenticate and download the file. We don't use the GitHub
-            # CLI for public repositories because it's subject to the GitHub REST
-            # API rate limit, while the raw URL is served by a CDN that is not.
-            if [[ "$REPO_VISIBILITY" == "public" ]]; then
-              DOWNLOAD_SUCCEEDED=$(curl -sSf -o "$NVMRC_TMP_FILE" "https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/.nvmrc" && echo "true" || echo "false")
-            else
-              DOWNLOAD_SUCCEEDED=$(gh api "repos/${OWNER_AND_REPO}/contents/.nvmrc?ref=${COMMIT_HASH}" --header "Accept: application/vnd.github.raw+json" > "$NVMRC_TMP_FILE" && echo "true" || echo "false")
-            fi
-
-            if [[ "$DOWNLOAD_SUCCEEDED" == "true" ]]; then
-              mv "$NVMRC_TMP_FILE" .nvmrc
-            else
-              rm -f "$NVMRC_TMP_FILE"
-              echo "::error::You must either have a .nvmrc at the requested ref, or provide the node-version input. Failed to download .nvmrc from ${OWNER_AND_REPO}@${COMMIT_HASH}"
-              exit 1
-            fi
+          if [[ ! -s "$NVMRC_FILE" ]]; then
+            echo "::error::You must either have a .nvmrc at the requested ref, or provide the node-version input."
+            exit 1
           fi
 
-          NODE_VERSION=$(tr -d '\r\n' < .nvmrc)
+          NODE_VERSION=$(tr -d '\r\n' < "$NVMRC_FILE")
         else
           NODE_VERSION="$INPUT_NODE_VERSION"
         fi
@@ -165,55 +242,62 @@ runs:
         echo "node-version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
         INPUT_NODE_VERSION: ${{ inputs.node-version }}
-        OWNER_AND_REPO: ${{ github.repository }}
-        COMMIT_HASH: ${{ inputs.ref || github.sha }}
-        REPO_VISIBILITY: ${{ github.event.repository.visibility }}
+        NVMRC_FILE: ${{ steps.download-repository-metadata.outputs.nvmrc-path }}
 
-    - name: Download yarn.lock from current commit in attempt to skip setup
-      if: ${{ inputs.is-high-risk-environment == 'false' && inputs.cache-node-modules == 'true' && inputs.skip-install != 'true' }}
-      id: download-yarn-lock
+    - name: Compute node_modules cache paths
+      if: ${{ (inputs.is-high-risk-environment == 'false' || inputs.cache-node-modules == 'true') && inputs.skip-install != 'true' }}
+      id: compute-node-modules-cache-paths
       run: |
-        if [[ ! -s yarn.lock ]]; then
-          YARN_LOCK_TMP_FILE="$(mktemp)"
+        CACHE_PATHS_TMP_FILE="$(mktemp)"
 
-          # For public repositories, we can download the raw file directly from
-          # the GitHub URL. For private repositories, we need to use the GitHub
-          # CLI to authenticate and download the file. We don't use the GitHub
-          # CLI for public repositories because it's subject to the GitHub REST
-          # API rate limit, while the raw URL is served by a CDN that is not.
-          if [[ "$REPO_VISIBILITY" == "public" ]]; then
-            DOWNLOAD_SUCCEEDED=$(curl -sSf -o "$YARN_LOCK_TMP_FILE" "https://raw.githubusercontent.com/${OWNER_AND_REPO}/${COMMIT_HASH}/yarn.lock" && echo "true" || echo "false")
-          else
-            DOWNLOAD_SUCCEEDED=$(gh api "repos/${OWNER_AND_REPO}/contents/yarn.lock?ref=${COMMIT_HASH}" --header "Accept: application/vnd.github.raw+json" > "$YARN_LOCK_TMP_FILE" && echo "true" || echo "false")
-          fi
-
-          if [[ "$DOWNLOAD_SUCCEEDED" == "true" ]]; then
-            # Only overwrite yarn.lock on a successful download.
-            mv "$YARN_LOCK_TMP_FILE" yarn.lock
-          else
-            rm -f "$YARN_LOCK_TMP_FILE"
-            echo "::warning::Failed to download yarn.lock from ${OWNER_AND_REPO}@${COMMIT_HASH}"
-            exit 1
-          fi
+        if [[ -s "$PACKAGE_JSON_FILE" ]]; then
+          # Cache Yarn's install-state file, the root node_modules directory,
+          # and one node_modules directory per workspace pattern declared in
+          # package.json. Yarn can create package-local node_modules folders in
+          # monorepos, but walking every nested node_modules directory with
+          # **/node_modules is expensive in large installs.
+          {
+            echo ".yarn/install-state.gz"
+            echo "node_modules"
+            jq -r '
+              (.workspaces // [])
+              | if type == "array" then .
+                elif type == "object" then (.packages // [])
+                elif type == "string" then [.]
+                else []
+                end
+              | .[]
+              | "\(.)/node_modules"
+            ' "$PACKAGE_JSON_FILE"
+          } | awk 'NF && !seen[$0]++' > "$CACHE_PATHS_TMP_FILE"
+        else
+          {
+            echo ".yarn/install-state.gz"
+            echo "**/node_modules"
+          } > "$CACHE_PATHS_TMP_FILE"
         fi
+
+        # actions/cache accepts a newline-delimited list through a multiline
+        # output. Remove empty lines and duplicates above so the cache action
+        # gets stable paths even if package.json contains overlapping patterns.
+        {
+          echo "paths<<EOF"
+          cat "$CACHE_PATHS_TMP_FILE"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        rm -f "$CACHE_PATHS_TMP_FILE"
       shell: bash
-      continue-on-error: true
       env:
-        GH_TOKEN: ${{ github.token }}
-        OWNER_AND_REPO: ${{ github.repository }}
-        COMMIT_HASH: ${{ inputs.ref || github.sha }}
-        REPO_VISIBILITY: ${{ github.event.repository.visibility }}
+        PACKAGE_JSON_FILE: ${{ steps.download-repository-metadata.outputs.package-json-path }}
 
     - name: Try skipping setup if node-modules cache available
-      if: ${{ inputs.is-high-risk-environment == 'false' && inputs.cache-node-modules == 'true' && steps.download-yarn-lock.outcome == 'success' && inputs.force-setup != 'true' && inputs.skip-install != 'true' }}
+      if: ${{ inputs.is-high-risk-environment == 'false' && inputs.cache-node-modules == 'true' && steps.download-repository-metadata.outputs.yarn-lock-available == 'true' && inputs.force-setup != 'true' && inputs.skip-install != 'true' }}
       id: try-skip-setup
       uses: actions/cache/restore@v6
       with:
-        path: |
-          .yarn/install-state.gz
-          node_modules
+        path: ${{ steps.compute-node-modules-cache-paths.outputs.paths }}
         key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
         lookup-only: true
 
@@ -266,9 +350,7 @@ runs:
       id: download-node-modules
       uses: actions/cache/restore@v6
       with:
-        path: |
-          .yarn/install-state.gz
-          node_modules
+        path: ${{ steps.compute-node-modules-cache-paths.outputs.paths }}
         key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
 
     - name: Conditionally restore action/setup-node cache
@@ -316,10 +398,8 @@ runs:
     # but we still save so that downstream PR jobs can read from the
     # main-branch cache scope (write-only mode).
     - name: Cache workspace
-      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && inputs.cache-node-modules == 'true' && inputs.skip-install != 'true' }}
+      if: ${{ steps.try-skip-setup.outputs.cache-hit != 'true' && steps.download-node-modules.outputs.cache-hit != 'true' && inputs.cache-node-modules == 'true' && inputs.skip-install != 'true' }}
       uses: actions/cache/save@v6
       with:
-        path: |
-          .yarn/install-state.gz
-          node_modules
+        path: ${{ steps.compute-node-modules-cache-paths.outputs.paths }}
         key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.compute-node-version.outputs.node-version }}-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
#78 broke support for monorepos.  This PR fixes that by making it compatible and faster in monorepos too.

- New step uses `jq` on `package.json` to compute the paths.  It falls back to the old `**/node_modules`.
- Instead of 3 separate steps to download `.nvmrc`, `yarn.lock`, and `package.json`, combines into a new `download-repository-metadata`.  Keeps the same `if` statements we had before for each download.
- More details on the descriptions of the `force-setup` input
- Added `corepack enable` to `create-release-pr.yml` (the release action failed without this)

Tested on `metamask-extension`: https://github.com/MetaMask/metamask-extension/actions/runs/28199740857
Tested on `core` moving everything to v3: https://github.com/MetaMask/core/actions/runs/28202403090/job/83545071824

Fixes: MetaMask/MetaMask-planning#7365

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CI caching and early-setup behavior for all consumers; incorrect workspace path derivation could miss monorepo `node_modules`, though the `**/node_modules` fallback limits breakage.
> 
> **Overview**
> Restores and speeds up **monorepo** support for `action-checkout-and-setup` by changing what gets cached and how paths are chosen before checkout.
> 
> A new **`download-repository-metadata`** step prefetches `.nvmrc`, `yarn.lock`, and `package.json` at the requested ref (public raw URL or authenticated `gh` for private repos) so Node version, cache keys, and lookup-only skip logic can run without an early full checkout. **`compute-node-modules-cache-paths`** builds cache paths from `package.json` workspaces via `jq` (`.yarn/install-state.gz`, root `node_modules`, plus each workspace’s `node_modules`), with **`**/node_modules`** as fallback when `package.json` isn’t available.
> 
> Cache **restore/save** and the lookup-only skip step use those dynamic paths instead of only root `node_modules`. **Cache save** is skipped when a full restore already hit, avoiding redundant writes. Docs clarify **`cache-node-modules`** and **`force-setup`**; **`create-release-pr.yml`** adds **`corepack enable`** so the release workflow can run Yarn reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d8f86e9d6026e53a413f41c3f3ab1ca8b6a4938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->