### PR TITLE
ci: fix publish environment name

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,7 +65,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    environment: npm-publish
+    environment: action-publish
     needs: announce-release
     permissions:
       contents: read


### PR DESCRIPTION
Fixes the `environment` name from `npm-publish` to `action-publish`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow environment rename with no application or security logic changes; wrong environment names could block or mis-route approvals until fixed.
> 
> **Overview**
> Updates the **`publish-release`** job in `.github/workflows/publish-release.yml` so its GitHub Actions **`environment`** is **`action-publish`** instead of **`npm-publish`**.
> 
> That environment name controls deployment protection rules and required approvals for the release publish step (which uses `MetaMask/action-publish-release@v3`), so the workflow should now target the intended environment rather than a misnamed one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e6b5ec7d2ca701fca0081dafeed1a6a325cf88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->